### PR TITLE
Upgraded bignum dependency since 0.4.1 uses deprecated node-waf

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
       "name": "buffermaker",
       "description" : "buffermaker is a convenient way of creating binary strings",
       "keywords" : ["buffer", "binary"],
-      "version": "0.1.0",
+      "version": "0.0.10",
       "bugs": {
        "url": "https://github.com/cainus/BufferMaker/issues"
       },


### PR DESCRIPTION
Discovered while trying to npm install prozess - this downstream dependency breaks on newer versions of Node.  If all looks good, please npm publish as well.  Thanks!

Change-Id: I8c44fb4e0ac131ced2af8a810cfdded99ef2f71c
